### PR TITLE
Fix extended macros to also work with ActionButtonUseKeyDown=1

### DIFF
--- a/MacroToolkit/MacroToolkit.lua
+++ b/MacroToolkit/MacroToolkit.lua
@@ -570,8 +570,9 @@ function MT:ExtendMacro(save, macrobody, idx, exists)
 	end
 	--modified 15/12/13 - need to ensure button info is passed to the secure frame
 	--local newbody = format("%s%s%s %s", showtooltip, show, MT.click, securebutton:GetName())
-	local n = format("MTSBP%d", exists and idx or index)
-	local newbody = format(exFormat, showtooltip, show, MT.click, n, n, n, n, n, MT.click, n)
+	local n = format("MTSB%d", exists and idx or index)
+	local np = format("MTSBP%d", exists and idx or index)
+	local newbody = format(exFormat, showtooltip, show, MT.click, n, n, n, n, n, MT.click, np)
 	if not idx then
 		MacroToolkitText.extended = true
 		_G[format("MacroToolkitButton%d", (MTF.selectedMacro - MTF.macroBase))].extended = true
@@ -598,22 +599,24 @@ function MT:CorrectExtendedMacros()
 		local body = select(3, GetMacroInfo(m))
 		if body then
 			if string.find(body, format("%s MacroToolkitSecureButton%%d+", MT.click)) then
-				local b = format("MTSBP%d", string.match(body, "MacroToolkitSecureButton(%d+)"))
+				local b = format("MTSB%d", string.match(body, "MacroToolkitSecureButton(%d+)"))
+				local bp = format("MTSBP%d", string.match(body, "MacroToolkitSecureButton(%d+)"))
 				local showtooltip = select(3, string.find(body, "(#showtooltip.-)\n"))
 				local show = select(3, string.find(body, "(#show .-)\n"))
 				if showtooltip then showtooltip = format("%s\n", showtooltip) else showtooltip = "" end
 				if show then show = format("%s\n", show) else show = "" end
-				local newbody = format(exFormat, showtooltip, show, MT.click, b, b, b, b, b, MT.click, b)
+				local newbody = format(exFormat, showtooltip, show, MT.click, b, b, b, b, b, MT.click, bp)
 				EditMacro(m, nil, nil, newbody)
 			end
 			-- upgrade for the 10.0.0 /click workaround
-			if string.find(body, format("%s %sMTSB%%d+", MT.click, '%[btn:1%]')) then
-				local b = format("MTSBP%d", string.match(body, "MTSB(%d+)"))
+			if string.find(body, format("%s %sMTSBP?%%d+", MT.click, '%[btn:1%]')) then
+				local b = format("MTSB%d", string.match(body, "MTSBP?(%d+)"))
+				local bp = format("MTSBP%d", string.match(body, "MTSBP?(%d+)"))
 				local showtooltip = select(3, string.find(body, "(#showtooltip.-)\n"))
 				local show = select(3, string.find(body, "(#show .-)\n"))
 				if showtooltip then showtooltip = format("%s\n", showtooltip) else showtooltip = "" end
 				if show then show = format("%s\n", show) else show = "" end
-				local newbody = format(exFormat, showtooltip, show, MT.click, b, b, b, b, b, MT.click, b)
+				local newbody = format(exFormat, showtooltip, show, MT.click, b, b, b, b, b, MT.click, bp)
 				EditMacro(m, nil, nil, newbody)
 			end
 		end

--- a/MacroToolkit/modules/mainframe.lua
+++ b/MacroToolkit/modules/mainframe.lua
@@ -976,14 +976,17 @@ function MT:CreateSecureActionButton(index)
 	proxy:SetAttribute("type", "click")
 	proxy:SetAttribute("clickbutton", frame)
 
-	-- lots of thanks to Mitälie#3150 for this magic :)
-	-- Configure the proxy to record mousebutton on downclick and override on upclick
-	SecureHandlerUnwrapScript(proxy, "OnClick")
+	-- Configure the button to record mousebutton on downclick
+	SecureHandlerWrapScript(frame, "OnClick", proxy, [[
+		if down then
+			owner:SetAttribute("origbutton", button)
+		end
+	]])
+
+	-- Configure the proxy to override mousebutton on upclick
 	SecureHandlerWrapScript(proxy, "OnClick", proxy, [[
-	  if down then
-		self:SetAttribute("origbutton", button)
-	  else
-		return self:GetAttribute("origbutton")
-	  end
+		if not down then
+			return self:GetAttribute("origbutton")
+		end
 	]])
 end

--- a/MacroToolkit/modules/mainframe.lua
+++ b/MacroToolkit/modules/mainframe.lua
@@ -972,6 +972,23 @@ function MT:CreateSecureActionButton(index)
 	frame:SetAttribute("dynamic", false)
 	frame:RegisterForClicks("AnyUp", "AnyDown")
 
+	-- As of patch 10.0.0, SecureActionButtonTemplate depends on ActionButtonUseKeyDown CVar and only performs its
+	-- action on either up or down click, not both. We don't want to override the user's preference for all action
+	-- buttons, so we have to work with whichever is chosen, e.g. by simply simulating both in the trigger macro.
+	--
+	-- Further, a long-standing bug in /click slash command means a down click is performed if and only if a button
+	-- name is passed. This means we can't simulate an up click with a non-default mouse button, and macros with
+	-- [btn:N] conditions would misbehave if executed on up click.
+	--
+	-- We can work around this limitation by simulating the down click first, recording the button to be used, and
+	-- restoring it as an override on the up click. Applying the override on the macrotext action button directly
+	-- gets only considered by the SABT machinery but macro options, GetMouseButtonClicked, etc, won't be aware of
+	-- it, therefore we must route it through :Click() using a proxy SAB with type=click. SABT type=click does not
+	-- pass down parameter and only performs up clicks, so down clicks must be done on the target button directly.
+	--
+	-- See exFormat variable and its usage in MacroToolkit.lua for the trigger macro.
+	--
+	-- This will likely need to be removed/reworked when https://github.com/Stanzilla/WoWUIBugs/issues/317 is fixed.
 	local proxy = CreateFrame("Button", format("MTSBP%d", index), nil, "SecureActionButtonTemplate")
 	proxy:SetAttribute("type", "click")
 	proxy:SetAttribute("clickbutton", frame)


### PR DESCRIPTION
Oops, I wrote my hack in a hurry and failed to test that my trick still worked with `ActionButtonUseKeyDown=1`.

Turns out `SECURE_ACTIONS.click` does not pass the down parameter, so the actual button gets always clicked with an up click and fails to execute its action with `ActionButtonUseKeyDown=1`. A secure down click can only be made with slash command, so the trigger macro must click the actual button directly.

To avoid having to repeat the `/click [btn:1]...` sequence on both the original button for the `ActionButtonUseKeyDown=1` and on the proxy button for `ActionButtonUseKeyDown=0`, we can also wrap the original button's click handler to capture the button there and set the attribute directly on the Restricted Environment owner.

Unwrap is not needed here, I only had it in my example to allow edit and re-execute without reloading the whole UI.

Changed indentation to tabs only for consistency.